### PR TITLE
Add bucket-brigade QRAM experiment

### DIFF
--- a/experiments/qram_bucket_brigade/README.md
+++ b/experiments/qram_bucket_brigade/README.md
@@ -1,0 +1,25 @@
+# Bucket-Brigade QRAM Simulation (2-qubit address)
+
+This experiment sketches a small, explicit "bucket-brigade" QRAM read using Qiskit. It treats two address qubits and a single data qubit as a four-cell classical memory and shows how to map a superposition of addresses to the corresponding entangled address–data state.
+
+## Problem instance
+- Address register: two qubits labeled `a0` (MSB) and `a1` (LSB).
+- Data register: one qubit `d`.
+- Classical contents: `d = [0, 1, 1, 0]`, meaning `00 → 0`, `01 → 1`, `10 → 1`, `11 → 0`.
+- Ideal map: \(\sum_i \alpha_i |i\rangle_A |0\rangle_D \mapsto \sum_i \alpha_i |i\rangle_A |d_i\rangle_D\).
+
+## Bucket-brigade interpretation
+Real bucket-brigade QRAM stores the address path through a binary tree of switches. With only two address qubits, that tree would have a single root (steered by `a0`) and two children (steered by `a1`). Here we compress the same control logic into multi-controlled X gates: for each address whose classical content is 1 we apply an `mcx` to the data qubit, controlling on the address qubits being in that computational basis state. Zero-controls are emulated with temporary X gates, mirroring how the tree would open the correct branch for a specific address.
+
+## What is in the notebook
+- Helper to prepare a chosen basis address.
+- `apply_qram_read` that adds multi-controlled X gates for every address with `d[i] = 1`.
+- Basis-state checks confirming the correct data bit is loaded.
+- Superposition experiment producing the entangled address–data state.
+- Resource estimation using `transpile(qc)` to report depth and gate counts for the three-qubit circuit.
+
+## Running the experiment
+1. Ensure `qiskit>=2.0.0` is installed (install with `pip install "qiskit>=2.0.0"`).
+2. Open `qram_bucket_brigade.ipynb` and run the cells. The transpilation cell prints gate counts and circuit depth for this two-address QRAM read. You can adjust `d` or extend to three address qubits to explore scaling.
+
+Figures can be saved to `experiments/qram_bucket_brigade/figures/` if you render the circuit diagram with the MPL drawer.

--- a/experiments/qram_bucket_brigade/qram_bucket_brigade.ipynb
+++ b/experiments/qram_bucket_brigade/qram_bucket_brigade.ipynb
@@ -1,0 +1,198 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "# Bucket-Brigade QRAM Read (toy 2-qubit address)\n",
+        "\n",
+        "This notebook builds a tiny QRAM read circuit in Qiskit using a bucket-brigade inspired control structure. The address register has two qubits and the data register has one qubit, giving four classical memory cells with contents `d = [0, 1, 1, 0]`. The goal is to realize the map\n",
+        "\n",
+        "$$\\sum_i \u0007lpha_i |i\n",
+        "angle_A |0\n",
+        "angle_D \\longmapsto \\sum_i \u0007lpha_i |i\n",
+        "angle_A |d_i\n",
+        "angle_D,$$\n",
+        "\n",
+        "without treating QRAM as a black-box oracle. Instead, we explicitly condition on the address bits to flip the data qubit wherever the stored classical bit is 1.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "## Phase 1 \u2013 Problem instance and bucket-brigade logic\n",
+        "\n",
+        "- Address qubits: `a0` (MSB), `a1` (LSB)\n",
+        "- Data qubit: `d`\n",
+        "- Classical memory: `d = [0, 1, 1, 0]` so `00 \u2192 0`, `01 \u2192 1`, `10 \u2192 1`, `11 \u2192 0`\n",
+        "- Ideal QRAM map: \\(\\sum_i \u0007lpha_i |i\n",
+        "angle_A |0\n",
+        "angle_D \to \\sum_i \u0007lpha_i |i\n",
+        "angle_A |d_i\n",
+        "angle_D\\).\n",
+        "\n",
+        "Bucket-brigade hardware would route the address down a binary tree of switches, storing the path. For two address qubits the tree has a root controlled by `a0` and two leaves controlled by `a1`. Here we compress that routing into multi-controlled X gates: for each address whose classical content is 1 we apply an `mcx` to the data qubit, using temporary X gates to emulate controls on `|0\n",
+        "angle` where needed.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "from __future__ import annotations\n",
+        "from typing import Iterable, List\n",
+        "\n",
+        "from qiskit import QuantumCircuit, transpile\n",
+        "from qiskit.quantum_info import Statevector\n",
+        "\n",
+        "num_addr = 2\n",
+        "num_data = 1\n",
+        "memory_bits = [0, 1, 1, 0]\n",
+        "\n",
+        "# Qubit layout: [a0, a1, d]\n",
+        "address_qubits = list(range(num_addr))\n",
+        "data_qubit = num_addr\n",
+        "\n",
+        "def prepare_address(qc: QuantumCircuit, addr_bits: str) -> None:\n",
+        "    '''Load a classical address (MSB-first string) into the address register.'''\n",
+        "    if len(addr_bits) != num_addr:\n",
+        "        raise ValueError(f\"Expected {num_addr} bits, got {len(addr_bits)}\")\n",
+        "    for qb, bit in zip(address_qubits, addr_bits):\n",
+        "        if bit == \"1\":\n",
+        "            qc.x(qb)\n",
+        "\n",
+        "def apply_qram_read(qc: QuantumCircuit, d: Iterable[int]) -> None:\n",
+        "    '''Apply bucket-brigade-inspired QRAM read based on classical memory d.'''\n",
+        "    for i, bit in enumerate(d):\n",
+        "        if bit != 1:\n",
+        "            continue\n",
+        "        addr_bits = format(i, f\"0{num_addr}b\")  # MSB -> LSB string\n",
+        "\n",
+        "        zero_controls: List[int] = [qb for qb, addr_bit in zip(address_qubits, addr_bits) if addr_bit == \"0\"]\n",
+        "        for qb in zero_controls:\n",
+        "            qc.x(qb)\n",
+        "\n",
+        "        qc.mcx(address_qubits, data_qubit)\n",
+        "\n",
+        "        for qb in zero_controls:\n",
+        "            qc.x(qb)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "## Phase 2 \u2013 Basis checks\n",
+        "\n",
+        "The circuit should flip the data qubit only for addresses `01` and `10`. We test each basis address using the statevector simulator and report the most likely bitstring (displayed as `a0 a1 d`).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "from collections import Counter\n",
+        "\n",
+        "\n",
+        "def simulate_basis_address(addr_bits: str):\n",
+        "    qc = QuantumCircuit(num_addr + num_data)\n",
+        "    prepare_address(qc, addr_bits)\n",
+        "    apply_qram_read(qc, memory_bits)\n",
+        "    state = Statevector.from_instruction(qc)\n",
+        "    probs = state.probabilities_dict()\n",
+        "    # Reorder bitstrings from qiskit's |q2 q1 q0> to |a0 a1 d>\n",
+        "    reordered = {bits[::-1]: p for bits, p in probs.items() if p > 1e-9}\n",
+        "    return Counter(reordered)\n",
+        "\n",
+        "for addr in [\"00\", \"01\", \"10\", \"11\"]:\n",
+        "    counts = simulate_basis_address(addr)\n",
+        "    top_state = counts.most_common(1)[0]\n",
+        "    print(f\"Address |{addr}> -> dominant state |{top_state[0]}> with probability {top_state[1]:.3f}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "## Phase 3 \u2013 Superposition address\n",
+        "\n",
+        "Prepare a uniform superposition over all addresses, apply the same QRAM read, and inspect the resulting entangled state. The expected output for `d = [0, 1, 1, 0]` is\n",
+        "\n",
+        "\\[\n",
+        "\tfrac{1}{2}\big(|00\n",
+        "angle|0\n",
+        "angle + |01\n",
+        "angle|1\n",
+        "angle + |10\n",
+        "angle|1\n",
+        "angle + |11\n",
+        "angle|0\n",
+        "angle\big).\n",
+        "\\]\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "superposition = QuantumCircuit(num_addr + num_data)\n",
+        "for qb in address_qubits:\n",
+        "    superposition.h(qb)\n",
+        "\n",
+        "apply_qram_read(superposition, memory_bits)\n",
+        "\n",
+        "state = Statevector.from_instruction(superposition)\n",
+        "probs = state.probabilities_dict()\n",
+        "filtered = {bits[::-1]: p for bits, p in probs.items() if p > 1e-9}\n",
+        "\n",
+        "print(\"Non-zero basis states (shown as a0 a1 d):\")\n",
+        "for bits, prob in sorted(filtered.items()):\n",
+        "    print(f\"|{bits}>: {prob:.3f}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "\n",
+        "## Phase 4 \u2013 Resource estimates\n",
+        "\n",
+        "We can get a sense of the cost of this logical QRAM read by transpiling the three-qubit circuit and inspecting depth and operation counts. The numbers below use Qiskit's default transpiler settings and keep the two `mcx` gates explicit.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "transpiled = transpile(superposition)\n",
+        "print(\"Circuit depth:\", transpiled.depth())\n",
+        "print(\"Operation counts:\", transpiled.count_ops())\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a bucket-brigade QRAM experiment folder describing the two-qubit address/readout setup
- include a notebook that builds the QRAM read circuit, checks basis and superposition cases, and reports resource estimates

## Testing
- not run (qiskit dependency unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f838b67388322a46823cf686968d1)