### PR TITLE
Relocate experiment docs to project directories

### DIFF
--- a/bb84-protocol/bb84_adaptive_noise_experiments.md
+++ b/bb84-protocol/bb84_adaptive_noise_experiments.md
@@ -1,0 +1,35 @@
+# BB84 Adaptive Noise Experiments
+
+## Goal
+Quantify how adaptive basis choices and error-reconciliation depth affect secret-key rates over realistic noisy channels, using Qiskit Aer noise models.
+
+## Experiment Design
+1. **Channel Models**  
+   - Depolarizing noise with probabilities p ∈ {0.0, 0.01, 0.03, 0.05}.  
+   - Amplitude damping with γ ∈ {0.0, 0.02, 0.05}.  
+   - Optional eavesdropper modeled as intercept-resend with probability ε ∈ {0, 0.1, 0.2}.
+2. **Adaptive Basis Bias**  
+   - Start with 50/50 Z/X basis.  
+   - After every 500 qubits, shift bias toward the lower-error basis observed in the previous block (e.g., 60/40, then 70/30).  
+   - Track the sifting rate and quantum bit error rate (QBER) per block.
+3. **Error Reconciliation Depth**  
+   - Run Cascade-style parity checks with 1–4 passes; measure leakage versus final key length.  
+   - Compare with a low-density parity-check (LDPC) decoder (if available) for the same syndrome budget.
+4. **Privacy Amplification**  
+   - Use universal hashing with different compression rates; estimate secure key length using finite-key analysis.
+
+## Metrics
+- QBER per block and cumulative.  
+- Secret-key rate (bits per channel use) under finite-key assumptions.  
+- Leakage from reconciliation versus final key length.  
+- Detection probability of ε-level eavesdropping.
+
+## Success Criteria
+- Identify a stable basis-bias schedule that maintains QBER < 11% under depolarizing noise p ≤ 0.03.  
+- Show at least 10% improvement in final key length when switching from fixed 50/50 bases to adaptive scheduling.  
+- Demonstrate detection of ε ≥ 0.1 intercept-resend with >95% confidence after 5k qubits.
+
+## Implementation Notes
+- Extend `bb84_simulation.py` to accept noise-channel knobs and basis-bias schedules.  
+- Use Qiskit Aer noise models (`DepolarizingError`, `AmplitudeDampingError`).  
+- Log blockwise metrics to CSV for later plotting.

--- a/grovers-search/grovers_robust_oracle_experiments.md
+++ b/grovers-search/grovers_robust_oracle_experiments.md
@@ -1,0 +1,31 @@
+# Grover's Search Robust Oracle Experiments
+
+## Goal
+Evaluate how Grover's quadratic speedup degrades when oracles are imperfect or when the marked item changes mid-run, simulating data drift.
+
+## Experiment Design
+1. **Imperfect Oracle Flips**  
+   - Implement an oracle that flips the marked state with probability (1 − δ) and leaves it unchanged with probability δ.  
+   - Sweep δ ∈ {0, 0.05, 0.1, 0.2} for search spaces N ∈ {8, 16, 64}.  
+   - Measure success probability after ⌊π/4√N⌋ and after an adaptive stop rule based on sampling shots.
+2. **Target Drift Mid-Run**  
+   - After k Grover iterations (k ∈ {2, 4}), change the marked item to a new index.  
+   - Compare performance of restarting versus continuing with a Bayesian guess of the new target.
+3. **Noise-Injection Stress Test**  
+   - Add depolarizing noise p ∈ {0, 0.01, 0.03}.  
+   - Compare standard diffusion operator to a fixed-point (Grover α) variant to see which tolerates noise better.
+
+## Metrics
+- Success probability of measuring the (possibly drifting) marked state.  
+- Number of oracle calls required to reach >80% success probability.  
+- Robustness delta: drop in success probability relative to the ideal oracle.
+
+## Success Criteria
+- Identify δ thresholds where the fixed-point Grover variant outperforms the standard implementation.  
+- Demonstrate that adaptive stopping rules save oracle calls when δ ≥ 0.1.  
+- Show that restarting after drift yields higher success than continuing for k ≥ 4 when N ≥ 16.
+
+## Implementation Notes
+- Extend the existing Grover script to accept oracle reliability δ and noise parameters.  
+- Log iteration-by-iteration success estimates and oracle call counts.  
+- Use Qiskit Aer for noise modeling; plot success probability versus iterations.

--- a/post-quantum-crypto/pqc_hybrid_benchmark_experiments.md
+++ b/post-quantum-crypto/pqc_hybrid_benchmark_experiments.md
@@ -1,0 +1,34 @@
+# Post-Quantum Cryptography Hybrid Benchmark Experiments
+
+## Goal
+Assess performance and security trade-offs of hybrid key exchange (classical + PQC) and hybrid signatures for small-enterprise settings.
+
+## Experiment Design
+1. **Hybrid Key Exchange**  
+   - Combine ECDH (P-256) with Kyber-512 and Kyber-768.  
+   - Measure handshake latency and bandwidth for TLS-style flows (ClientHello/ServerHello with hybrid KEM).  
+   - Include a simulated post-quantum downgrade attacker that strips PQC payloads; verify detection via transcript checksums.
+2. **Hybrid Signatures**  
+   - Benchmark Ed25519+Dilithium2 and ECDSA(P-256)+Falcon-512 for signing and verification throughput.  
+   - Vary batch sizes {1, 10, 100} to test verification parallelism overhead.  
+   - Track signature sizes and total TLS certificate chain weight.
+3. **Side-Channel Robustness Smoke Tests**  
+   - Introduce timing noise and measure variance of key generation and decapsulation.  
+   - Flag any correlation between secret-dependent branches and runtime using simple Welch’s t-tests on timing samples.
+
+## Metrics
+- Latency (ms) and bandwidth (KB) for handshake flows.  
+- CPU time per operation for sign/verify and encapsulate/decapsulate.  
+- Failure detection rate for PQC downgrade attack.  
+- Timing side-channel test statistics (p-values) to highlight risky implementations.
+
+## Success Criteria
+- Demonstrate hybrid KEM adds <40% latency over pure ECDH for small payloads.  
+- Show Dilithium2 hybrid signatures keep certificate chain growth under 10 KB.  
+- Detect downgrade attempts with >99% reliability using transcript checksums.  
+- Identify any statistically significant timing leakage (p < 0.01) in naive implementations.
+
+## Implementation Notes
+- Use `pqcrypto` or `liboqs` Python bindings for Kyber, Dilithium, and Falcon where available; fall back to placeholder timing mocks if unavailable.  
+- Script TLS-like message flow in Python; log packet sizes and timestamps.  
+- Keep raw timing samples (CSV) for reproducibility and side-channel analysis.

--- a/shors-algorithm/shors_fault_tolerant_scaling_experiments.md
+++ b/shors-algorithm/shors_fault_tolerant_scaling_experiments.md
@@ -1,0 +1,34 @@
+# Shor's Algorithm Fault-Tolerant Scaling Experiments
+
+## Goal
+Explore resource scaling and resilience when running Shor’s algorithm with error-mitigation and early abort heuristics on composite numbers beyond 15.
+
+## Experiment Design
+1. **Target Numbers and Circuits**  
+   - Factor n ∈ {15, 21, 33, 35}.  
+   - Use Qiskit’s modular exponentiation building blocks; tally total 1- and 2-qubit gate counts and depth.
+2. **Error Mitigation Variants**  
+   - Compare zero-noise extrapolation (ZNE), probabilistic error cancellation (PEC), and measurement error mitigation (M3) under depolarizing noise p ∈ {0, 0.002, 0.005}.  
+   - Run each variant with 4k shots; record success probability of recovering the correct factors.
+3. **Early Abort Heuristic**  
+   - After each phase-estimation run, compute classical post-processing confidence.  
+   - Abort further shots if two consecutive attempts yield co-prime failure results (gcd = 1) to save resources; track shot savings.
+4. **Logical Encoding Stress Test (Optional)**  
+   - Replace physical qubits with [[5,1,3]] code logical qubits using basic stabilizer encoding.  
+   - Estimate logical depth and overhead versus physical execution.
+
+## Metrics
+- Total gate counts, circuit depth, and number of controlled-U operations.  
+- Success probability of factoring each n with/without mitigation.  
+- Shots saved by early abort compared to fixed-shot baselines.  
+- Resource overhead for logical encoding.
+
+## Success Criteria
+- Demonstrate ≥20% shot savings on average with the early abort heuristic while maintaining factoring success within 5% of the baseline.  
+- Show that ZNE or PEC improves factoring success probability by >10 percentage points when p ≥ 0.002.  
+- Provide resource estimates (qubits, depth) for logical encoding that highlight feasibility gaps.
+
+## Implementation Notes
+- Extend `shors_algorithm.py` to toggle noise models, mitigation strategies, and early-abort logic.  
+- Use Qiskit Aer for noise and mitigation primitives; gather raw results as JSON/CSV for analysis.  
+- Visualize gate-depth growth versus target n to communicate scaling trends.


### PR DESCRIPTION
## Summary
- move BB84 adaptive noise experiment plan into the bb84-protocol folder
- move Grover, PQC hybrid, and Shor experiment plans into their corresponding project directories
- keep central experiments folder for unrelated qram materials

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8bd0413c8322b46d4bf66d528d7d)