### PR TITLE
Fix Grover oracle wiring in toy QRAM demo

### DIFF
--- a/experiments/qram_grover_search/toy_qram_grover.py
+++ b/experiments/qram_grover_search/toy_qram_grover.py
@@ -125,7 +125,7 @@ def run_toy_grover(data_bits: Iterable[int], target_value: int = 1) -> None:
     oracle_gate = build_oracle(data_list, target_value)
     diffuser_gate = diffuser(address_bits)
 
-    grover.append(oracle_gate, grover.qubits[:-1])
+    grover.append(oracle_gate, grover.qubits)
     grover.append(diffuser_gate, address)
     grover.measure(address, classical)
 


### PR DESCRIPTION
### Motivation
- The Grover oracle was attached only to the address register (omitting the data qubit) so it could not act on the data qubit and therefore broke the intended QRAM-backed oracle behavior.

### Description
- In `experiments/qram_grover_search/toy_qram_grover.py` replace `grover.append(oracle_gate, grover.qubits[:-1])` with `grover.append(oracle_gate, grover.qubits)` to pass the full address+data register to the oracle.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a650509288322ac1b6558f90ae6ae)