### PR TITLE
Fix scaler data leakage by fitting on training set only

### DIFF
--- a/Quantum_Machine_Learning/experiments/experiment_01/experiment.py
+++ b/Quantum_Machine_Learning/experiments/experiment_01/experiment.py
@@ -95,16 +95,18 @@ def run_experiment(
     algorithm_globals.random_seed = seed
     raw_data, labels, is_nominal = generate_synthetic_dataset(seed=seed)
 
-    scaler = MinMaxScaler(feature_range=(-1.0, 1.0))
-    scaled_data = scaler.fit_transform(raw_data)
-
-    nominal_data = scaled_data[is_nominal]
+    nominal_data = raw_data[is_nominal]
     n_train = int(len(nominal_data) * train_fraction)
-    train_data = nominal_data[:n_train]
-    test_data = scaled_data[n_train:]
+
+    train_data_raw = nominal_data[:n_train]
+    test_data_raw = raw_data[n_train:]
     test_labels = labels[n_train:]
 
-    quantum_kernel = build_quantum_kernel(feature_dimension=scaled_data.shape[1])
+    scaler = MinMaxScaler(feature_range=(-1.0, 1.0))
+    train_data = scaler.fit_transform(train_data_raw)
+    test_data = scaler.transform(test_data_raw)
+
+    quantum_kernel = build_quantum_kernel(feature_dimension=train_data.shape[1])
     _, quantum_predictions = evaluate_quantum_kernel_svm(quantum_kernel, train_data, test_data)
     _, classical_predictions = evaluate_classical_baseline(train_data, test_data)
 


### PR DESCRIPTION
### Motivation
- The experiment previously fit `MinMaxScaler` on the full dataset before splitting, which leaks test-set statistics into training and invalidates evaluation metrics.
- The change prevents this leakage by ensuring scaler parameters come only from the training split.

### Description
- Updated `run_experiment` in `Quantum_Machine_Learning/experiments/experiment_01/experiment.py` to split raw data before scaling by introducing `train_data_raw` and `test_data_raw` and computing `n_train` from nominal samples.
- Fit `MinMaxScaler(feature_range=(-1.0, 1.0))` on `train_data_raw` with `scaler.fit_transform()` and apply `scaler.transform()` to `test_data_raw` so test statistics are not used for fitting.
- Adjusted the quantum kernel feature dimension to use `train_data.shape[1]` and kept the downstream evaluation (`evaluate_quantum_kernel_svm` and `evaluate_classical_baseline`) unchanged.

### Testing
- Ran `python -m compileall Quantum_Machine_Learning/experiments/experiment_01/experiment.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15ebb20e588322b1bd733f6710de0b)