### PR TITLE
Implement real `--noise` behavior in experiment CLI

### DIFF
--- a/Quantum_Machine_Learning/experiments/experiment_01/README.md
+++ b/Quantum_Machine_Learning/experiments/experiment_01/README.md
@@ -52,6 +52,8 @@ now lives in `qiskit_algorithms.utils`.
 
 ```bash
 python experiments/experiment_01/experiment.py
+python experiments/experiment_01/experiment.py --noise
+python experiments/experiment_01/experiment.py --noise --noise-probability 0.03
 ```
 
 The script prints precision/recall metrics for the quantum kernel model and a

--- a/Quantum_Machine_Learning/experiments/experiment_01/experiment.py
+++ b/Quantum_Machine_Learning/experiments/experiment_01/experiment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import argparse
 from typing import Tuple
 
 import numpy as np
@@ -12,6 +13,7 @@ from sklearn.svm import OneClassSVM
 
 # --- Qiskit imports ---
 from qiskit_aer import AerSimulator
+from qiskit_aer.noise import NoiseModel, depolarizing_error
 from qiskit.circuit.library import ZZFeatureMap
 from qiskit_machine_learning.kernels import FidelityQuantumKernel
 from qiskit_algorithms.utils import algorithm_globals
@@ -59,6 +61,28 @@ def build_quantum_kernel(feature_dimension: int, reps: int = 2) -> FidelityQuant
     return FidelityQuantumKernel(feature_map=feature_map, backend=backend)
 
 
+def depolarizing_noise_model(probability: float = 0.01) -> NoiseModel:
+    """Create a simple depolarizing noise model for 1q and 2q basis gates."""
+    if not 0.0 <= probability < 1.0:
+        raise ValueError("probability must be in [0.0, 1.0).")
+
+    noise_model = NoiseModel()
+    noise_model.add_all_qubit_quantum_error(depolarizing_error(probability, 1), ["rz", "sx", "x"])
+    noise_model.add_all_qubit_quantum_error(
+        depolarizing_error(probability, 2),
+        ["cx"],
+    )
+    return noise_model
+
+
+def build_noisy_quantum_kernel(
+    feature_dimension: int, reps: int = 2, noise_probability: float = 0.01
+) -> FidelityQuantumKernel:
+    feature_map = ZZFeatureMap(feature_dimension=feature_dimension, reps=reps)
+    backend = AerSimulator(noise_model=depolarizing_noise_model(noise_probability))
+    return FidelityQuantumKernel(feature_map=feature_map, backend=backend)
+
+
 # ----------------------------
 # Evaluators
 # ----------------------------
@@ -87,7 +111,7 @@ def evaluate_classical_baseline(
 # Experiment runner
 # ----------------------------
 def run_experiment(
-    *, train_fraction: float = 0.75, seed: int = 7
+    *, train_fraction: float = 0.75, seed: int = 7, use_noise: bool = False, noise_probability: float = 0.01
 ) -> QuantumAnomalyDetectionResult:
     if not 0.1 <= train_fraction <= 0.95:
         raise ValueError("train_fraction should be between 0.1 and 0.95 for stability.")
@@ -104,7 +128,14 @@ def run_experiment(
     test_data = scaled_data[n_train:]
     test_labels = labels[n_train:]
 
-    quantum_kernel = build_quantum_kernel(feature_dimension=scaled_data.shape[1])
+    quantum_kernel = (
+        build_noisy_quantum_kernel(
+            feature_dimension=scaled_data.shape[1],
+            noise_probability=noise_probability,
+        )
+        if use_noise
+        else build_quantum_kernel(feature_dimension=scaled_data.shape[1])
+    )
     _, quantum_predictions = evaluate_quantum_kernel_svm(quantum_kernel, train_data, test_data)
     _, classical_predictions = evaluate_classical_baseline(train_data, test_data)
 
@@ -126,8 +157,33 @@ def run_experiment(
 # Entry point
 # ----------------------------
 def main() -> None:
-    result = run_experiment()
+    parser = argparse.ArgumentParser(description="Run quantum kernel anomaly detection experiment.")
+    parser.add_argument("--train-fraction", type=float, default=0.75, help="Fraction of nominal data used for training.")
+    parser.add_argument("--seed", type=int, default=7, help="Random seed used for reproducibility.")
+    parser.add_argument(
+        "--noise",
+        action="store_true",
+        help="Enable depolarizing noise model on the quantum simulator.",
+    )
+    parser.add_argument(
+        "--noise-probability",
+        type=float,
+        default=0.01,
+        help="Depolarizing error probability when --noise is enabled.",
+    )
+    args = parser.parse_args()
+
+    result = run_experiment(
+        train_fraction=args.train_fraction,
+        seed=args.seed,
+        use_noise=args.noise,
+        noise_probability=args.noise_probability,
+    )
     print("Quantum kernel anomaly detection report:\n")
+    if args.noise:
+        print(f"[noise enabled] depolarizing probability={args.noise_probability}\n")
+    else:
+        print("[noise disabled] running ideal simulator\n")
     print(result.quantum_report)
     print("Classical RBF baseline report:\n")
     print(result.classical_report)


### PR DESCRIPTION
### Motivation
- The CLI exposed `--noise` in docs but the runtime never read `args.noise` or applied a noise model, so noisy and noiseless runs were identical and the advertised noise experiment was unavailable.

### Description
- Added an `argparse`-driven CLI in `experiment.py` with `--noise` and `--noise-probability` flags and preserved `--train-fraction` and `--seed` options.
- Implemented `depolarizing_noise_model(probability)` using `qiskit_aer.noise` and a `build_noisy_quantum_kernel` that wires `AerSimulator(noise_model=...)` into the `FidelityQuantumKernel`.
- Extended `run_experiment` to accept `use_noise` and `noise_probability` and to conditionally build a noisy or ideal quantum kernel based on the parsed flags.
- Updated `experiments/experiment_01/README.md` run examples to include noisy execution examples so docs match behavior.

### Testing
- Ran `python -m py_compile Quantum_Machine_Learning/experiments/experiment_01/experiment.py` and it succeeded.
- Ran `python Quantum_Machine_Learning/experiments/experiment_01/experiment.py --help` and the CLI help printed successfully showing the new flags.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15ebcbb56483228d15fc4f8bcd6b9e)