### PR TITLE
Fix QRAM kernel input validation for empty/mismatched data

### DIFF
--- a/experiments/qram_qml_kernel/qram_qml_kernel.py
+++ b/experiments/qram_qml_kernel/qram_qml_kernel.py
@@ -19,6 +19,10 @@ class QRAMConfig:
 
     features: List[float]
 
+    def __post_init__(self) -> None:
+        if not self.features:
+            raise ValueError("features must contain at least one value")
+
     @property
     def thetas(self) -> List[float]:
         return [math.pi * x for x in self.features]
@@ -51,6 +55,11 @@ def kernel_matrix(thetas: List[float]) -> List[List[float]]:
 
 
 def classify(test_feature: float, training_thetas: List[float], labels: List[int]) -> int:
+    if not training_thetas:
+        raise ValueError("training_thetas must not be empty")
+    if len(training_thetas) != len(labels):
+        raise ValueError("training_thetas and labels must have the same length")
+
     theta_test = math.pi * test_feature
     fidelities = [fidelity(theta_test, ti) for ti in training_thetas]
     return labels[fidelities.index(max(fidelities))]

--- a/tests/test_qram_qml_kernel.py
+++ b/tests/test_qram_qml_kernel.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from experiments.qram_qml_kernel.qram_qml_kernel import QRAMConfig, classify
+
+
+def test_qram_config_requires_non_empty_features():
+    with pytest.raises(ValueError, match="at least one value"):
+        QRAMConfig(features=[])
+
+
+def test_classify_rejects_empty_training_data():
+    with pytest.raises(ValueError, match="must not be empty"):
+        classify(0.5, [], [])
+
+
+def test_classify_rejects_mismatched_labels():
+    with pytest.raises(ValueError, match="same length"):
+        classify(0.5, [0.1, 0.9], [1])


### PR DESCRIPTION
### Motivation
- Prevent surprising runtime math errors when users supply empty feature lists to the QRAM demo by failing early with a clear message.
- Ensure `classify` behaves predictably for invalid inputs by validating empty training sets and mismatched label lengths.

### Description
- Added `__post_init__` to `QRAMConfig` to raise `ValueError("features must contain at least one value")` when `features` is empty in `experiments/qram_qml_kernel/qram_qml_kernel.py`.
- Added input checks to `classify` to raise `ValueError("training_thetas must not be empty")` for empty training data and `ValueError("training_thetas and labels must have the same length")` for mismatched lengths.
- Added `tests/test_qram_qml_kernel.py` with three regression tests that exercise the new validation paths.

### Testing
- Ran `pytest -q tests/test_qram_qml_kernel.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f736a49c8322ad0d1a2cde7bf515)