### PR TITLE
Fix QRAM address qubit count for single-feature configs

### DIFF
--- a/experiments/qram_qml_kernel/qram_qml_kernel.py
+++ b/experiments/qram_qml_kernel/qram_qml_kernel.py
@@ -34,7 +34,8 @@ class QRAMConfig:
     @property
     def address_qubits(self) -> int:
         # Enough qubits to index every training point.  Only one is needed for 2 points.
-        return math.ceil(math.log2(self.num_addresses))
+        # Keep at least one wire for routing/control even with one stored item.
+        return max(1, math.ceil(math.log2(self.num_addresses)))
 
 
 def rotation_state(theta: float) -> List[float]:

--- a/tests/test_qram_qml_kernel.py
+++ b/tests/test_qram_qml_kernel.py
@@ -21,3 +21,8 @@ def test_classify_rejects_empty_training_data():
 def test_classify_rejects_mismatched_labels():
     with pytest.raises(ValueError, match="same length"):
         classify(0.5, [0.1, 0.9], [1])
+
+
+def test_qram_config_uses_at_least_one_address_qubit():
+    config = QRAMConfig(features=[0.42])
+    assert config.address_qubits == 1


### PR DESCRIPTION
### Motivation
- Prevent `QRAMConfig.address_qubits` from returning 0 for single-feature configs because `ceil(log2(1))` equals 0, which undercounts required routing/control wiring in QRAM demos.

### Description
- Update `QRAMConfig.address_qubits` to `return max(1, math.ceil(math.log2(self.num_addresses)))` to guarantee at least one address qubit in `experiments/qram_qml_kernel/qram_qml_kernel.py`.
- Add a regression test `test_qram_config_uses_at_least_one_address_qubit` in `tests/test_qram_qml_kernel.py` that asserts a single-feature config yields `address_qubits == 1`.

### Testing
- Ran `pytest -q` and the test suite passed with `4 passed` (including the new regression test).
- The modified test file is `tests/test_qram_qml_kernel.py` and it verifies the fix automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f9eb133483228d6cd1671c8f9213)