### PR TITLE
Fix kernel CSV header generation for variable dataset sizes

### DIFF
--- a/experiments/qram_qml_kernel/qram_qml_kernel.py
+++ b/experiments/qram_qml_kernel/qram_qml_kernel.py
@@ -82,7 +82,8 @@ def save_kernel_matrix(path: str, kernel: List[List[float]]) -> None:
     with open(path, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["Kernel matrix K(i,j) = |<psi_i|psi_j>|^2"])
-        writer.writerow(["", "x0", "x1"])
+        headers = ["", *[f"x{idx}" for idx in range(len(kernel))]]
+        writer.writerow(headers)
         for idx, row in enumerate(kernel):
             writer.writerow([f"x{idx}", *[f"{val:.6f}" for val in row]])
 

--- a/tests/test_qram_qml_kernel.py
+++ b/tests/test_qram_qml_kernel.py
@@ -5,7 +5,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from experiments.qram_qml_kernel.qram_qml_kernel import QRAMConfig, classify
+from experiments.qram_qml_kernel.qram_qml_kernel import QRAMConfig, classify, save_kernel_matrix
 
 
 def test_qram_config_requires_non_empty_features():
@@ -26,3 +26,11 @@ def test_classify_rejects_mismatched_labels():
 def test_qram_config_uses_at_least_one_address_qubit():
     config = QRAMConfig(features=[0.42])
     assert config.address_qubits == 1
+
+
+def test_save_kernel_matrix_writes_dynamic_headers(tmp_path):
+    output = tmp_path / "kernel.csv"
+    save_kernel_matrix(str(output), [[1.0, 0.5, 0.25], [0.5, 1.0, 0.5], [0.25, 0.5, 1.0]])
+
+    rows = output.read_text().splitlines()
+    assert rows[1] == ",x0,x1,x2"


### PR DESCRIPTION
### Motivation
- The CSV export in `save_kernel_matrix` used a hard-coded two-column header (`x0,x1`) which produced malformed CSVs for kernels larger than 2×2 and needed to scale with the matrix size.

### Description
- Replace the fixed header with dynamically generated headers `headers = ["", *[f"x{idx}" for idx in range(len(kernel))]]` in `experiments/qram_qml_kernel/qram_qml_kernel.py` and add `test_save_kernel_matrix_writes_dynamic_headers` (importing `save_kernel_matrix`) to `tests/test_qram_qml_kernel.py` that asserts the header for a 3×3 kernel is `,x0,x1,x2`.

### Testing
- Ran `pytest -q` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15fc274b608322a0034b85e244600f)